### PR TITLE
Add IMU_SKIP option to save power and add two time-zones

### DIFF
--- a/include/mpu.hpp
+++ b/include/mpu.hpp
@@ -16,4 +16,5 @@ int16_t getBearing();
 int calibrateBearing();
 void calibrateGyro();
 void mpuSleep();
+void mpuDeepSleep();
 float getTemperature();

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,6 +38,7 @@ build_flags =
   -DLOAD_GFXFF=1
   -DSMOOTH_FONT=1
   -DSPI_FREQUENCY=27000000
+;  -DIMU_SKIP         # remove comment to keep IMU (accelerometer, gyrometer and magnetometer) shut down
 monitor_speed = 115200
 lib_ldf_mode = deep+
 lib_deps = 

--- a/src/hardware/mpu.cpp
+++ b/src/hardware/mpu.cpp
@@ -79,3 +79,13 @@ float getTemperature()
   float temperature = ((float)tempCount) / 333.87 + 21.0;
   return temperature;
 }
+
+// Based on example code by Kris Winer at https://github.com/kriswiner/MPU9250/issues/162#issuecomment-336604802
+void mpuDeepSleep()
+{
+  IMU.writeByte(MPU9250_ADDRESS, PWR_MGMT_1, IMU.readByte(MPU9250_ADDRESS, PWR_MGMT_1) | 0x40); // set sleep mode bit(6), disable all sensors
+  delay(100); // wait for all registers to reset
+  IMU.writeByte(AK8963_ADDRESS, AK8963_CNTL, IMU.readByte(AK8963_ADDRESS, AK8963_CNTL) & ~(0x0F) ); // clear bits 0 to 3 to power down magnetometer
+  IMU.writeByte(MPU9250_ADDRESS, PWR_MGMT_1, IMU.readByte(MPU9250_ADDRESS, PWR_MGMT_1) | 0x10); // write bit 4 to enable gyro standby
+  delay(10); // wait for all registers to reset
+}

--- a/src/hardware/sleep.cpp
+++ b/src/hardware/sleep.cpp
@@ -4,11 +4,18 @@ void handleSleep(bool showMsg)
 {
   //tftSleep(showMsg);
   mpuSleep();
+#ifndef IMU_SKIP
+  mpuSleep();
+#endif
   tftSleep(false);
   deactivateWifi();
   rtcSleep();
   pinMode(39, GPIO_MODE_INPUT);
+#ifndef IMU_SKIP
   esp_sleep_enable_ext1_wakeup(GPIO_SEL_33 | GPIO_SEL_39, ESP_EXT1_WAKEUP_ANY_HIGH);
+#else
+  esp_sleep_enable_ext1_wakeup(GPIO_SEL_33, ESP_EXT1_WAKEUP_ANY_HIGH);
+#endif
   esp_deep_sleep_disable_rom_logging();
   esp_deep_sleep_start();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,11 @@ void setup()
   deactivateWifi();
   btStop();
   setupADC();
+#ifndef IMU_SKIP
   initMPU();
+#else
+  mpuDeepSleep();
+#endif
   initButton();
   setupBattery();
 }

--- a/src/pages/pages.cpp
+++ b/src/pages/pages.cpp
@@ -60,13 +60,21 @@ void showPage()
     pageBattery(initialLoad);
     break;
   case 3:
+#ifndef IMU_SKIP
     max_time_out = 60000;
     pageBearing(initialLoad);
     break;
+#else
+    page++;
+#endif
   case 4:
+#ifndef IMU_SKIP
     max_time_out = 30000;
     pageTemperature(initialLoad);
     break;
+#else
+    page++;
+#endif
   case 5:
     max_time_out = 15000;
     pageOta(initialLoad);
@@ -94,7 +102,9 @@ void handleAction()
     waitOta();
     break;
   case 3:
+#ifndef IMU_SKIP
     actionBearing();
+#endif
     break;
   case 5:
     waitOta();


### PR DESCRIPTION
Add in IMU_SKIP option to prevent wake up by IMU and to lower IMU power usage while asleep

Add in code for AEST and AEDT time zones

Enabling IMU_SKIP will lower power usage as discussed in https://github.com/TioRuben/TTGO-T-Wristband/issues/5#issue-601598702

Enabling TZ_AEDT or TZ_AEST will use another time zone to the default CEST/CET and can be used to help add other time-zones by searching in code for TZ_AEDT. 

The code also fixes an issue identified in https://github.com/TioRuben/TTGO-T-Wristband/issues/4#issue-601589323

The code has no effect unless comment enablers are removed in platformio.ini:
```
;  -DIMU_SKIP         # remove comment to keep IMU (accelerometer, gyrometer and magnetometer) shut down
;  -DTZ_AEDT          # AEDT Australian Eastern Daylight Time. Defaults to CEST/CET if no TZ (Time Zone) defined
;  -DTZ_AEST          # AEST Australian Eastern Standard Time (QLD only)
```

